### PR TITLE
Update Lamdas and Method References code block indents 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ private fun renderField() {
 }
 
 private fun getTouchPointers() = (0..6).filter(input::isTouched)
-										.map { viewport.unproject(TouchPoint(it)) }
-										.filter { !it.isZero }
+	.map { viewport.unproject(TouchPoint(it)) }
+	.filter { !it.isZero }
 ```
 This demonstrates two different types of method references. The `Ring::isFull` points to the `isFull`of the `Iterable<Ring>`. Hopefuly `Ring` can be omitted due a smart compiler. 
 In the second example the `renderer::renderStone` points a function of the `renderer`. That’s called a **bound reference** which points to it’s reviever.


### PR DESCRIPTION
I wasn't sure if this was intentional or not, but the spacing for these two methods in the documentation seemed a bit off.  